### PR TITLE
Add Count param to GetIdentityTransfersInTickRangeV2

### DIFF
--- a/protobuff/archive.pb.go
+++ b/protobuff/archive.pb.go
@@ -3041,6 +3041,7 @@ type GetTransferTransactionsPerTickRequestV2 struct {
 	EndTick   uint32 `protobuf:"varint,3,opt,name=end_tick,json=endTick,proto3" json:"end_tick,omitempty"`
 	ScOnly    bool   `protobuf:"varint,4,opt,name=sc_only,json=scOnly,proto3" json:"sc_only,omitempty"`
 	Desc      bool   `protobuf:"varint,5,opt,name=desc,proto3" json:"desc,omitempty"`
+	Count     uint32 `protobuf:"varint,6,opt,name=count,proto3" json:"count,omitempty"`
 }
 
 func (x *GetTransferTransactionsPerTickRequestV2) Reset() {

--- a/rpc/v2_endpoints.go
+++ b/rpc/v2_endpoints.go
@@ -375,6 +375,10 @@ func (s *Server) GetIdentityTransfersInTickRangeV2(ctx context.Context, req *pro
 
 	}
 
+    if req.Count > 0 && len(totalTransactions) > int(req.Count) {
+        totalTransactions = totalTransactions[:req.Count]
+    }
+
 	return &protobuff.GetIdentityTransfersInTickRangeResponseV2{
 		Transactions: totalTransactions,
 	}, nil


### PR DESCRIPTION
PR for https://github.com/qubic/go-archiver/issues/56

Adds optional **Count** param to GetIdentityTransfersInTickRangeV2