### PR TITLE
adding profiling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN chmod +x /app/go-archiver
 
 EXPOSE 8000
 EXPOSE 8001
+EXPOSE 8002
 
 WORKDIR /app
 

--- a/main.go
+++ b/main.go
@@ -11,6 +11,8 @@ import (
 	"github.com/qubic/go-archiver/validator/tick"
 	qubic "github.com/qubic/go-node-connector"
 	"log"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"runtime"
@@ -34,6 +36,7 @@ func run() error {
 			ShutdownTimeout   time.Duration `conf:"default:5s"`
 			HttpHost          string        `conf:"default:0.0.0.0:8000"`
 			GrpcHost          string        `conf:"default:0.0.0.0:8001"`
+			ProfilingHost     string        `conf:"default:0.0.0.0:8002"`
 			NodeSyncThreshold int           `conf:"default:3"`
 			ChainTickFetchUrl string        `conf:"default:http://127.0.0.1:8080/max-tick"`
 		}
@@ -178,6 +181,12 @@ func run() error {
 	// Start the service listening for requests.
 	go func() {
 		procErrors <- proc.Start()
+	}()
+
+	pprofErrors := make(chan error, 1)
+
+	go func() {
+		pprofErrors <- http.ListenAndServe(cfg.Server.ProfilingHost, nil)
 	}()
 
 	for {


### PR DESCRIPTION
## Usage

There are multiple type of profiling that one can perform on a program: cpu, memory, heap. I will write an example for cpu and for the other types examples can be found here: https://medium.com/@srajsonu/efficient-debugging-with-pprof-in-go-b2e63e4b167e

`go tool pprof http://localhost:8002/debug/pprof/profile\?seconds\=30`

Then in interactive mode you can generate the pdf

## Things to consider

When deploying with docker, port 8002 needs to be mapped to guest localhost to be accessible.